### PR TITLE
Use desc for name

### DIFF
--- a/lib/puppet/provider/user_right/secedit.rb
+++ b/lib/puppet/provider/user_right/secedit.rb
@@ -4,7 +4,7 @@ begin
   require File.expand_path('../../../util/ini_file', __FILE__)
 rescue LoadError
   # in case we're not in libdir
-  require File.expand_path('../../../../../spec/fixtures/modules/inifile/lib/puppet/util/ini_file', __FILE__)
+  # require File.expand_path('../../../../../spec/fixtures/modules/inifile/lib/puppet/util/ini_file', __FILE__)
 end
 
 Puppet::Type.type(:user_right).provide(:secedit) do

--- a/lib/puppet/type/user_right.rb
+++ b/lib/puppet/type/user_right.rb
@@ -13,10 +13,20 @@ Puppet::Type.newtype(:user_right) do
         desc 'The user right name'
 
         validate do |value|
-            fail "Not a valid name: '#{value}'" unless value =~ /^[A-Za-z]+$/
+            unless SecurityPolicy.valid_lsp?(value) or SecurityPolicy.find_mapping_from_policy_name(value)
+                raise ArgumentError, "Invalid Policy name: #{value}"
+            end
         end
 
         munge do |value|
+            if value.to_s =~ /\s+/
+                begin
+                    policy_hash = SecurityPolicy.find_mapping_from_policy_desc(value)
+                    value = policy_hash[:name]
+                rescue KeyError => e
+                    fail(e.message)
+                end
+            end
             value.downcase
         end
     end

--- a/lib/puppet/type/user_right_assignment.rb
+++ b/lib/puppet/type/user_right_assignment.rb
@@ -11,10 +11,20 @@ Puppet::Type.newtype(:user_right_assignment) do
         desc 'The right to append users to'
 
         validate do |value|
-            fail "Not a valid right name: '#{value}'" unless value =~ /^[A-Za-z]+$/
+            unless SecurityPolicy.valid_lsp?(value) or SecurityPolicy.find_mapping_from_policy_name(value)
+                raise ArgumentError, "Invalid Policy name: #{value}"
+            end
         end
 
         munge do |value|
+            if value.to_s =~ /\s+/
+                begin
+                    policy_hash = SecurityPolicy.find_mapping_from_policy_desc(value)
+                    value = policy_hash[:name]
+                rescue KeyError => e
+                    fail(e.message)
+                end
+            end
             value.downcase
         end
     end

--- a/metadata.json
+++ b/metadata.json
@@ -8,6 +8,10 @@
   "project_page": "https://github.com/camptocamp/puppet-ura",
   "issues_url": "https://github.com/camptocamp/puppet-ura/issues",
   "dependencies": [
+    {
+      "name": "local_security_policy",
+      "version_requirement": ">= 0.6.0 <1.0.0"
+    }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
This allows for people to use the description to specify the rights rather than the internal name, e.g.:
user_right { 'Adjust memory quotas for a process':
  ensure => present,
  sid    => ['CORP\domain', 'CORP\entadmin'],
}